### PR TITLE
Only match stateless functional components where the first letter is a capital

### DIFF
--- a/accelerator/src/accelerator.js
+++ b/accelerator/src/accelerator.js
@@ -84,7 +84,7 @@ handlers.close = function() {
     process.send({type: 'closed'});
     process.disconnect();
   }
-  process.exit();  
+  process.exit();
 };
 
 handlers.initPayload = function(data) {
@@ -120,7 +120,7 @@ handlers.setCacheDir = function(dir) {
   });
 };
 
-// get file data from build plugin   
+// get file data from build plugin
 handlers.fileData = function(files) {
   // hothacks.js guarantees that these are all new
   for (var key in files)
@@ -314,7 +314,7 @@ hot.transformStateless = function(source, path) {
   // const MyComponent = ({prop1, prop2}) => ();
   // const MyComponent = (props) => ();
   // const MyComponent = (props, context) => ();  TODO context
-  source = source.replace(/\nconst ([^ ]+) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]+) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n);')
         return match;
@@ -327,7 +327,7 @@ hot.transformStateless = function(source, path) {
     });
 
   // const MyComponent = (prop1, prop2) => { return ( < ... > ) };
-  source = source.replace(/\nconst ([^ ]+) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]+) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n};' || !code.match(/return\s+\(\s*\</))
         return match;

--- a/babel-compiler-hot/hothacks.js
+++ b/babel-compiler-hot/hothacks.js
@@ -158,7 +158,7 @@ hot.transformStateless = function(source, path) {
   // const MyComponent = ({prop1, prop2}) => ();
   // const MyComponent = (props) => ();
   // const MyComponent = (props, context) => ();  TODO context
-  source = source.replace(/\nconst ([^ ]+) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]+) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n);')
         return match;
@@ -171,7 +171,7 @@ hot.transformStateless = function(source, path) {
     });
 
   // const MyComponent = (prop1, prop2) => { return ( < ... > ) };
-  source = source.replace(/\nconst ([^ ]+) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]+) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n};' || !code.match(/return\s+\(\s*\</))
         return match;
@@ -221,7 +221,7 @@ function startFork() {
 
     console.log('[gadicc:hot] Build plugin got unknown message: '
       + JSON.stringify(msg));
-  });  
+  });
 
 }
 
@@ -267,7 +267,7 @@ hot.forFork = function(inputFiles, instance, fake) {
 
 /*
     if (!hot.lastHash[path]
-        // || packageName !== null 
+        // || packageName !== null
         || inputFileArch !== 'web.browser'
         || inputFilePath.match(/^tests\//)
         || inputFilePath.match(/tests?\.jsx?$/)


### PR DESCRIPTION
This is the standard in React.

A lot of false positives will occur from accepting lower case
functions.

This closes #30.