### PR TITLE
Put changes back in that were accidentally removed in c367dfc

### DIFF
--- a/accelerator/src/accelerator.js
+++ b/accelerator/src/accelerator.js
@@ -314,7 +314,7 @@ hot.transformStateless = function(source, path) {
   // const MyComponent = ({prop1, prop2}) => ();
   // const MyComponent = (props) => ();
   // const MyComponent = (props, context) => ();  TODO context
-  source = source.replace(/\nconst ([A-Z][^ ]+) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]*) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n);')
         return match;
@@ -327,7 +327,7 @@ hot.transformStateless = function(source, path) {
     });
 
   // const MyComponent = (prop1, prop2) => { return ( < ... > ) };
-  source = source.replace(/\nconst ([A-Z][^ ]+) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]*) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n};' || !code.match(/return\s+\(\s*\</))
         return match;

--- a/babel-compiler-hot/hothacks.js
+++ b/babel-compiler-hot/hothacks.js
@@ -160,7 +160,7 @@ hot.transformStateless = function(source, path) {
   // const MyComponent = ({prop1, prop2}) => ();
   // const MyComponent = (props) => ();
   // const MyComponent = (props, context) => ();  TODO context
-  source = source.replace(/\nconst ([^ ]+) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]*) = \((.*?)\) => \(([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n);')
         return match;
@@ -173,7 +173,7 @@ hot.transformStateless = function(source, path) {
     });
 
   // const MyComponent = (prop1, prop2) => { return ( < ... > ) };
-  source = source.replace(/\nconst ([^ ]+) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
+  source = source.replace(/\nconst ([A-Z][^ ]*) = \((.*?)\) => \{([\s\S]+?)(\n\S+)/g,
     function(match, className, args, code, rest) {
       if (rest !== '\n};' || !code.match(/return\s+\(\s*\</))
         return match;
@@ -223,7 +223,7 @@ function startFork() {
 
     console.log('[gadicc:hot] Build plugin got unknown message: '
       + JSON.stringify(msg));
-  });  
+  });
 
 }
 
@@ -290,7 +290,7 @@ hot.forFork = function(inputFiles, instance, fake) {
 
 /*
     if (!hot.lastHash[path]
-        // || packageName !== null 
+        // || packageName !== null
         || inputFileArch !== 'web.browser'
         || inputFilePath.match(/^tests\//)
         || inputFilePath.match(/tests?\.jsx?$/)


### PR DESCRIPTION
I also made the [^ ] match 0 or more rather than 1 or more since there is now a match for a capital letter at the start of the component name match and it could theoretically be a single capital letter.

Fixes #42 